### PR TITLE
Add VS Code tunnel VM deployment with independent workflow

### DIFF
--- a/.github/workflows/vscode-tunnel.yml
+++ b/.github/workflows/vscode-tunnel.yml
@@ -1,0 +1,121 @@
+name: 'VS Code Tunnel - Deploy'
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'Action to perform'
+        required: true
+        default: 'apply'
+        type: choice
+        options:
+          - apply
+          - destroy
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  vscode-tunnel:
+    name: 'VS Code Tunnel - ${{ inputs.action }}'
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./vscode-tunnel
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Authenticate to Google Cloud
+      uses: google-github-actions/auth@v2
+      with:
+        workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+        service_account: ${{ secrets.WIF_SERVICE_ACCOUNT_GKE }}
+
+    - name: Set up Cloud SDK
+      uses: google-github-actions/setup-gcloud@v2
+
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v3
+      with:
+        terraform_version: "1.5.0"
+        terraform_wrapper: false
+
+    - name: Terraform Format
+      id: fmt
+      run: terraform fmt -check
+      continue-on-error: true
+
+    - name: Terraform Init
+      id: init
+      run: |
+        terraform init \
+          -backend-config="bucket=sandbox-juangar-terraform-state" \
+          -backend-config="prefix=terraform/vscode-tunnel"
+
+    - name: Terraform Validate
+      id: validate
+      run: terraform validate -no-color
+
+    - name: Terraform Plan
+      id: plan
+      run: |
+        if [ "${{ inputs.action }}" == "destroy" ]; then
+          terraform plan -destroy -no-color -input=false
+        else
+          terraform plan -no-color -input=false
+        fi
+
+    - name: Terraform Apply/Destroy
+      id: apply
+      run: |
+        if [ "${{ inputs.action }}" == "destroy" ]; then
+          terraform destroy -auto-approve -input=false
+        else
+          terraform apply -auto-approve -input=false
+        fi
+
+    - name: Get Terraform Outputs
+      if: inputs.action == 'apply'
+      id: outputs
+      run: |
+        echo "instance_name=$(terraform output -raw instance_name)" >> $GITHUB_OUTPUT
+        echo "instance_zone=$(terraform output -raw instance_zone)" >> $GITHUB_OUTPUT
+        echo "external_ip=$(terraform output -raw external_ip)" >> $GITHUB_OUTPUT
+        echo "service_account=$(terraform output -raw service_account_email)" >> $GITHUB_OUTPUT
+
+    - name: Display Setup Instructions
+      if: inputs.action == 'apply'
+      run: |
+        echo "=================================================="
+        echo "VS Code Tunnel VM Deployed Successfully!"
+        echo "=================================================="
+        echo "Instance Name: ${{ steps.outputs.outputs.instance_name }}"
+        echo "Instance Zone: ${{ steps.outputs.outputs.instance_zone }}"
+        echo "External IP: ${{ steps.outputs.outputs.external_ip }}"
+        echo "Service Account: ${{ steps.outputs.outputs.service_account }}"
+        echo ""
+        echo "To complete the setup:"
+        echo "1. SSH into the VM:"
+        echo "   gcloud compute ssh ${{ steps.outputs.outputs.instance_name }} --zone=${{ steps.outputs.outputs.instance_zone }}"
+        echo ""
+        echo "2. Switch to the vscode-tunnel user:"
+        echo "   sudo su - vscode-tunnel"
+        echo ""
+        echo "3. Start the tunnel and authenticate:"
+        echo "   code tunnel --accept-server-license-terms"
+        echo ""
+        echo "4. Follow the authentication URL displayed"
+        echo ""
+        echo "5. After authentication, exit and enable the service:"
+        echo "   exit"
+        echo "   sudo systemctl enable vscode-tunnel"
+        echo "   sudo systemctl start vscode-tunnel"
+        echo ""
+        echo "6. Access your VS Code tunnel at:"
+        echo "   https://vscode.dev/tunnel/<machine-name>"
+        echo "=================================================="

--- a/vscode-tunnel/README.md
+++ b/vscode-tunnel/README.md
@@ -1,0 +1,159 @@
+# VS Code Tunnel VM
+
+This directory contains Terraform configuration to deploy a free-tier Google Cloud VM that runs VS Code tunnel, allowing you to access VS Code in your browser from anywhere.
+
+## Overview
+
+This setup creates:
+- An `e2-micro` VM instance (free tier eligible)
+- A dedicated service account for the VM
+- Firewall rules for HTTPS and SSH access
+- Automatic installation of VS Code CLI
+- A systemd service for running the tunnel
+
+## Prerequisites
+
+- Google Cloud project with billing enabled
+- Workload Identity Federation configured
+- Terraform state bucket created
+- GitHub secrets configured:
+  - `WIF_PROVIDER`
+  - `WIF_SERVICE_ACCOUNT_GKE`
+
+## Free Tier Eligibility
+
+This configuration uses:
+- `e2-micro` instance in `us-central1` (free tier eligible)
+- 30GB standard persistent disk (within free tier limit)
+- Standard network tier
+
+## Deployment
+
+### Via GitHub Actions
+
+1. Go to the Actions tab in GitHub
+2. Select "VS Code Tunnel - Deploy" workflow
+3. Click "Run workflow"
+4. Select action: `apply` to create or `destroy` to delete
+5. Click "Run workflow" button
+
+### Via Local Terraform
+
+```bash
+cd vscode-tunnel
+terraform init \
+  -backend-config="bucket=sandbox-juangar-terraform-state" \
+  -backend-config="prefix=terraform/vscode-tunnel"
+terraform plan
+terraform apply
+```
+
+## Setup Instructions
+
+After the VM is deployed, you need to authenticate the VS Code tunnel:
+
+1. SSH into the VM:
+   ```bash
+   gcloud compute ssh vscode-tunnel-vm --zone=us-central1-a
+   ```
+
+2. Switch to the vscode-tunnel user:
+   ```bash
+   sudo su - vscode-tunnel
+   ```
+
+3. Start the tunnel and authenticate:
+   ```bash
+   code tunnel --accept-server-license-terms
+   ```
+
+4. You'll see output like:
+   ```
+   * To grant access to the server, please log into https://github.com/login/device
+     and use code XXXX-XXXX
+   ```
+
+5. Visit the URL and enter the code to authenticate
+
+6. Once authenticated, exit the user session and enable the service:
+   ```bash
+   exit
+   sudo systemctl enable vscode-tunnel
+   sudo systemctl start vscode-tunnel
+   ```
+
+## Accessing Your VS Code Tunnel
+
+After authentication, access your VS Code environment at:
+```
+https://vscode.dev/tunnel/<machine-name>
+```
+
+The machine name is `vscode-tunnel-vm` by default.
+
+## Managing the Service
+
+### Check service status:
+```bash
+sudo systemctl status vscode-tunnel
+```
+
+### View logs:
+```bash
+sudo journalctl -u vscode-tunnel -f
+```
+
+### Restart service:
+```bash
+sudo systemctl restart vscode-tunnel
+```
+
+### Stop service:
+```bash
+sudo systemctl stop vscode-tunnel
+```
+
+## Cost Considerations
+
+While the e2-micro instance is free tier eligible, be aware of:
+- Free tier includes 1 e2-micro instance per month in specific regions
+- Network egress charges may apply beyond free tier limits
+- External IP addresses may incur charges
+
+Always monitor your GCP billing dashboard.
+
+## Cleanup
+
+To destroy the resources:
+
+Via GitHub Actions:
+1. Go to Actions → "VS Code Tunnel - Deploy"
+2. Run workflow with action: `destroy`
+
+Via local Terraform:
+```bash
+cd vscode-tunnel
+terraform destroy
+```
+
+## Troubleshooting
+
+### Can't connect to tunnel
+- Check if the service is running: `sudo systemctl status vscode-tunnel`
+- Verify authentication: `sudo su - vscode-tunnel` then `code tunnel status`
+- Check logs: `sudo journalctl -u vscode-tunnel -f`
+
+### Startup script issues
+- View startup script logs: `sudo journalctl -u google-startup-scripts.service`
+- Check the log file: `sudo cat /var/log/vscode-tunnel-setup.log`
+
+### Firewall issues
+- Verify firewall rules: `gcloud compute firewall-rules list | grep vscode-tunnel`
+- Ensure HTTPS (443) is allowed
+
+## Security Notes
+
+- The VM uses OS Login for SSH access
+- A dedicated service account is created with minimal permissions
+- Firewall rules allow HTTPS from any IP (required for tunnel access)
+- Consider restricting SSH access to specific IPs if needed

--- a/vscode-tunnel/main.tf
+++ b/vscode-tunnel/main.tf
@@ -1,0 +1,106 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "gcs" {
+    bucket = "sandbox-juangar-terraform-state"
+    prefix = "terraform/vscode-tunnel"
+  }
+}
+
+# Configure the Google Cloud provider
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+# Create a service account for the VS Code tunnel VM
+resource "google_service_account" "vscode_tunnel" {
+  account_id   = "vscode-tunnel-sa"
+  display_name = "VS Code Tunnel Service Account"
+  description  = "Service account for VS Code tunnel VM"
+}
+
+# Create firewall rule to allow HTTPS traffic (required for VS Code tunnel)
+resource "google_compute_firewall" "vscode_tunnel_https" {
+  name    = "vscode-tunnel-allow-https"
+  network = "default"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["443"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["vscode-tunnel"]
+}
+
+# Create firewall rule to allow SSH
+resource "google_compute_firewall" "vscode_tunnel_ssh" {
+  name    = "vscode-tunnel-allow-ssh"
+  network = "default"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["vscode-tunnel"]
+}
+
+# Create the VM instance for VS Code tunnel
+resource "google_compute_instance" "vscode_tunnel" {
+  name         = var.instance_name
+  machine_type = var.machine_type
+  zone         = var.zone
+
+  # Use free tier eligible boot disk
+  boot_disk {
+    initialize_params {
+      image = var.boot_disk_image
+      size  = var.boot_disk_size
+      type  = "pd-standard" # Standard persistent disk (free tier eligible)
+    }
+  }
+
+  # Network configuration
+  network_interface {
+    network = "default"
+
+    # Assign an ephemeral external IP
+    access_config {
+      network_tier = "STANDARD" # Standard tier for free tier eligibility
+    }
+  }
+
+  # Service account configuration
+  service_account {
+    email  = google_service_account.vscode_tunnel.email
+    scopes = ["cloud-platform"]
+  }
+
+  # Tags for firewall rules
+  tags = ["vscode-tunnel"]
+
+  # Metadata startup script to install and configure VS Code tunnel
+  metadata_startup_script = file("${path.module}/startup-script.sh")
+
+  # Metadata for SSH keys and other configuration
+  metadata = {
+    enable-oslogin = "TRUE"
+  }
+
+  # Allow stopping the instance to update it
+  allow_stopping_for_update = true
+
+  labels = {
+    environment = "development"
+    purpose     = "vscode-tunnel"
+  }
+}

--- a/vscode-tunnel/outputs.tf
+++ b/vscode-tunnel/outputs.tf
@@ -1,0 +1,40 @@
+output "instance_name" {
+  description = "Name of the VS Code tunnel VM instance"
+  value       = google_compute_instance.vscode_tunnel.name
+}
+
+output "instance_zone" {
+  description = "Zone where the VM instance is running"
+  value       = google_compute_instance.vscode_tunnel.zone
+}
+
+output "external_ip" {
+  description = "External IP address of the VM instance"
+  value       = google_compute_instance.vscode_tunnel.network_interface[0].access_config[0].nat_ip
+}
+
+output "internal_ip" {
+  description = "Internal IP address of the VM instance"
+  value       = google_compute_instance.vscode_tunnel.network_interface[0].network_ip
+}
+
+output "service_account_email" {
+  description = "Service account email for the VS Code tunnel VM"
+  value       = google_service_account.vscode_tunnel.email
+}
+
+output "tunnel_setup_instructions" {
+  description = "Instructions to check the VS Code tunnel setup"
+  value       = <<-EOT
+    To check the VS Code tunnel setup status:
+    1. SSH into the VM: gcloud compute ssh ${google_compute_instance.vscode_tunnel.name} --zone=${google_compute_instance.vscode_tunnel.zone}
+    2. Check the startup script logs: sudo journalctl -u google-startup-scripts.service
+    3. Check VS Code CLI status: code tunnel status
+
+    To authenticate and start using the tunnel:
+    1. SSH into the VM
+    2. Run: code tunnel user login
+    3. Follow the authentication prompts
+    4. Your tunnel will be accessible via https://vscode.dev/tunnel/<machine-name>
+  EOT
+}

--- a/vscode-tunnel/startup-script.sh
+++ b/vscode-tunnel/startup-script.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+set -e
+
+# Log file for debugging
+LOGFILE="/var/log/vscode-tunnel-setup.log"
+exec > >(tee -a ${LOGFILE}) 2>&1
+
+echo "Starting VS Code Tunnel setup at $(date)"
+
+# Update system packages
+echo "Updating system packages..."
+apt-get update
+apt-get upgrade -y
+
+# Install required dependencies
+echo "Installing dependencies..."
+apt-get install -y curl wget gpg apt-transport-https
+
+# Download and install VS Code CLI
+echo "Downloading VS Code CLI..."
+cd /tmp
+curl -Lk 'https://code.visualstudio.com/sha/download?build=stable&os=cli-alpine-x64' --output vscode_cli.tar.gz
+
+# Extract VS Code CLI
+echo "Extracting VS Code CLI..."
+tar -xf vscode_cli.tar.gz
+
+# Move to system path
+echo "Installing VS Code CLI..."
+mv code /usr/local/bin/
+chmod +x /usr/local/bin/code
+
+# Verify installation
+echo "Verifying VS Code CLI installation..."
+code --version
+
+# Create a dedicated user for running the tunnel
+echo "Creating vscode tunnel user..."
+if ! id -u vscode-tunnel > /dev/null 2>&1; then
+    useradd -m -s /bin/bash vscode-tunnel
+fi
+
+# Create systemd service for VS Code tunnel
+echo "Creating systemd service..."
+cat > /etc/systemd/system/vscode-tunnel.service <<'EOF'
+[Unit]
+Description=VS Code Tunnel
+After=network.target
+
+[Service]
+Type=simple
+User=vscode-tunnel
+WorkingDirectory=/home/vscode-tunnel
+ExecStart=/usr/local/bin/code tunnel --accept-server-license-terms --name vscode-tunnel-vm
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Reload systemd
+echo "Reloading systemd..."
+systemctl daemon-reload
+
+# Note: The tunnel service needs manual authentication on first run
+# Users need to SSH into the VM and run: sudo systemctl start vscode-tunnel
+# Then check logs with: sudo journalctl -u vscode-tunnel -f
+# They will see an authentication URL to visit
+
+echo "VS Code Tunnel setup completed at $(date)"
+echo ""
+echo "==================================================================="
+echo "IMPORTANT: Manual authentication required!"
+echo "==================================================================="
+echo "To complete the setup:"
+echo "1. SSH into this VM"
+echo "2. Switch to vscode-tunnel user: sudo su - vscode-tunnel"
+echo "3. Run: code tunnel --accept-server-license-terms"
+echo "4. Follow the authentication URL displayed"
+echo "5. After authentication, exit and enable the service:"
+echo "   sudo systemctl enable vscode-tunnel"
+echo "   sudo systemctl start vscode-tunnel"
+echo "==================================================================="

--- a/vscode-tunnel/variables.tf
+++ b/vscode-tunnel/variables.tf
@@ -1,0 +1,41 @@
+variable "project_id" {
+  description = "The Google Cloud project ID"
+  type        = string
+  default     = "sandbox-juangar"
+}
+
+variable "region" {
+  description = "The Google Cloud region"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "zone" {
+  description = "The Google Cloud zone for the VM instance"
+  type        = string
+  default     = "us-central1-a"
+}
+
+variable "instance_name" {
+  description = "Name of the VS Code tunnel VM instance"
+  type        = string
+  default     = "vscode-tunnel-vm"
+}
+
+variable "machine_type" {
+  description = "Machine type for the VM (e2-micro is free tier eligible)"
+  type        = string
+  default     = "e2-micro"
+}
+
+variable "boot_disk_image" {
+  description = "Boot disk image for the VM"
+  type        = string
+  default     = "ubuntu-os-cloud/ubuntu-2204-lts"
+}
+
+variable "boot_disk_size" {
+  description = "Boot disk size in GB (30GB is free tier limit)"
+  type        = number
+  default     = 30
+}


### PR DESCRIPTION
This commit adds infrastructure code to deploy a free-tier GCP VM that runs VS Code tunnel, enabling browser-based VS Code access from anywhere.

Changes:
- Created vscode-tunnel/ directory with Terraform configuration
- Added e2-micro VM instance (free tier eligible) with Ubuntu 22.04
- Configured automatic VS Code CLI installation via startup script
- Created systemd service for running tunnel persistently
- Added independent GitHub Actions workflow for deployment
- Included comprehensive README with setup and troubleshooting guide
- Configured firewall rules for HTTPS and SSH access
- Created dedicated service account for VM

The deployment can be managed independently via the "VS Code Tunnel - Deploy" GitHub Actions workflow without affecting the main GKE cluster resources.