### PR TITLE
Parameterize GCP project and add WIF-as-code bootstrap

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -21,6 +21,10 @@ jobs:
     name: 'Bootstrap State Bucket - ${{ inputs.action }}'
     runs-on: ubuntu-latest
 
+    env:
+      TF_VAR_project_id:  ${{ vars.GCP_PROJECT_ID }}
+      TF_VAR_github_repo: ${{ github.repository }}
+
     defaults:
       run:
         shell: bash
@@ -34,12 +38,11 @@ jobs:
       uses: google-github-actions/auth@v3
       with:
         workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
-        service_account: ${{ secrets.WIF_SERVICE_ACCOUNT_GCS}}
+        service_account: ${{ secrets.WIF_SERVICE_ACCOUNT_GCS }}
         token_format: 'access_token'
 
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@v3
-
 
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v3
@@ -62,17 +65,17 @@ jobs:
       id: plan
       run: |
         if [ "${{ inputs.action }}" == "destroy" ]; then
-          terraform plan -destroy -no-color -input=false -var="service_account_email=gcs-sa@sandbox-juangar.iam.gserviceaccount.com"
+          terraform plan -destroy -no-color -input=false
         else
-          terraform plan -no-color -input=false -var="service_account_email=gcs-sa@sandbox-juangar.iam.gserviceaccount.com"
+          terraform plan -no-color -input=false
         fi
 
     - name: Terraform Apply/Destroy
       run: |
         if [ "${{ inputs.action }}" == "destroy" ]; then
-          terraform destroy -auto-approve -input=false -var="service_account_email=gcs-sa@sandbox-juangar.iam.gserviceaccount.com"
+          terraform destroy -auto-approve -input=false
         else
-          terraform apply -auto-approve -input=false -var="service_account_email=gcs-sa@sandbox-juangar.iam.gserviceaccount.com"
+          terraform apply -auto-approve -input=false
         fi
 
     - name: Output State Bucket Name

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -27,6 +27,9 @@ jobs:
     name: 'Terraform - ${{ github.event.inputs.action || github.event_name }}'
     runs-on: ubuntu-latest
 
+    env:
+      TF_VAR_project_id: ${{ vars.GCP_PROJECT_ID }}
+
     defaults:
       run:
         shell: bash
@@ -56,7 +59,7 @@ jobs:
     - name: Terraform Init
       run: |
         terraform init \
-          -backend-config="bucket=sandbox-juangar-terraform-state" \
+          -backend-config="bucket=${{ vars.GCP_PROJECT_ID }}-terraform-state" \
           -backend-config="prefix=terraform/state"
 
     - name: Terraform Validate

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ crash.*.log
 # Exclude all .tfvars files, which are likely to contain sensitive data
 *.tfvars
 *.tfvars.json
+!*.tfvars.example
 
 # Ignore override files as they are usually used to override resources locally
 override.tf

--- a/bootstrap/main.tf
+++ b/bootstrap/main.tf
@@ -6,17 +6,35 @@ terraform {
       version = "~> 5.0"
     }
   }
-  
-  backend "gcs" {
-    bucket = "sandbox-juangar-terraform-state"
-    prefix = "terraform/state"
-  }
+
+  # Bootstrap uses local state because it creates the remote state bucket.
+  # Run this locally with `gcloud auth application-default login` first.
 }
 
 provider "google" {
   project = var.project_id
   region  = var.region
 }
+
+data "google_project" "current" {}
+
+# ---------- Enable required APIs ----------
+
+resource "google_project_service" "required_apis" {
+  for_each = toset([
+    "iam.googleapis.com",
+    "iamcredentials.googleapis.com",
+    "sts.googleapis.com",
+    "container.googleapis.com",
+    "compute.googleapis.com",
+    "cloudresourcemanager.googleapis.com",
+  ])
+
+  service            = each.value
+  disable_on_destroy = false
+}
+
+# ---------- GCS state bucket ----------
 
 resource "google_storage_bucket" "terraform_state" {
   name     = "${var.project_id}-terraform-state"
@@ -46,11 +64,3 @@ resource "google_storage_bucket" "terraform_state" {
     }
   }
 }
-
-/* resource "google_storage_bucket_iam_member" "terraform_state_admin" {
-  bucket = google_storage_bucket.terraform_state.name
-  role   = "roles/storage.admin"
-  member = "serviceAccount:${var.service_account_email}"
-} */
-
-##

--- a/bootstrap/outputs.tf
+++ b/bootstrap/outputs.tf
@@ -1,9 +1,24 @@
 output "state_bucket_name" {
-  description = "Name of the created state bucket"
+  description = "Name of the Terraform state bucket"
   value       = google_storage_bucket.terraform_state.name
 }
 
 output "state_bucket_url" {
-  description = "URL of the created state bucket"
+  description = "URL of the Terraform state bucket"
   value       = google_storage_bucket.terraform_state.url
+}
+
+output "wif_provider" {
+  description = "WIF provider resource name — set as WIF_PROVIDER GitHub secret"
+  value       = google_iam_workload_identity_pool_provider.github.name
+}
+
+output "service_account_gke" {
+  description = "GKE service account email — set as WIF_SERVICE_ACCOUNT_GKE GitHub secret"
+  value       = google_service_account.terraform_gke.email
+}
+
+output "service_account_gcs" {
+  description = "GCS service account email — set as WIF_SERVICE_ACCOUNT_GCS GitHub secret"
+  value       = google_service_account.terraform_gcs.email
 }

--- a/bootstrap/terraform.tfvars.example
+++ b/bootstrap/terraform.tfvars.example
@@ -1,0 +1,6 @@
+# Copy this file to terraform.tfvars and fill in your values.
+# terraform.tfvars is gitignored and will not be committed.
+
+project_id  = "your-gcp-project-id"
+region      = "us-central1"
+github_repo = "your-github-username/your-repo-name"

--- a/bootstrap/variables.tf
+++ b/bootstrap/variables.tf
@@ -1,7 +1,6 @@
 variable "project_id" {
-  description = "The Google Cloud project ID to deploy the resources in."
+  description = "The Google Cloud project ID."
   type        = string
-  default     = "sandbox-juangar"
 }
 
 variable "region" {
@@ -10,8 +9,7 @@ variable "region" {
   default     = "us-central1"
 }
 
-variable "service_account_email" {
-  description = "The service account email that will access the state bucket."
+variable "github_repo" {
+  description = "The GitHub repository allowed to authenticate via WIF (owner/repo)."
   type        = string
-  default     = "gcs-sa@sandbox-juangar.iam.gserviceaccount.com"
 }

--- a/bootstrap/wif.tf
+++ b/bootstrap/wif.tf
@@ -1,0 +1,94 @@
+# ---------- Service Accounts ----------
+
+resource "google_service_account" "terraform_gke" {
+  account_id   = "terraform-deploy"
+  display_name = "Terraform GKE Deploy"
+  description  = "Used by GitHub Actions to deploy GKE infrastructure"
+
+  depends_on = [google_project_service.required_apis]
+}
+
+resource "google_service_account" "terraform_gcs" {
+  account_id   = "gcs-sa"
+  display_name = "Terraform GCS State"
+  description  = "Used by GitHub Actions to manage Terraform state bucket"
+
+  depends_on = [google_project_service.required_apis]
+}
+
+# ---------- IAM: GKE Service Account ----------
+
+resource "google_project_iam_member" "gke_container_admin" {
+  project = var.project_id
+  role    = "roles/container.admin"
+  member  = "serviceAccount:${google_service_account.terraform_gke.email}"
+}
+
+resource "google_project_iam_member" "gke_compute_admin" {
+  project = var.project_id
+  role    = "roles/compute.admin"
+  member  = "serviceAccount:${google_service_account.terraform_gke.email}"
+}
+
+resource "google_project_iam_member" "gke_sa_user" {
+  project = var.project_id
+  role    = "roles/iam.serviceAccountUser"
+  member  = "serviceAccount:${google_service_account.terraform_gke.email}"
+}
+
+# GKE SA needs read/write access to the state bucket.
+resource "google_storage_bucket_iam_member" "gke_state_access" {
+  bucket = google_storage_bucket.terraform_state.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.terraform_gke.email}"
+}
+
+# ---------- IAM: GCS Service Account ----------
+
+resource "google_storage_bucket_iam_member" "gcs_state_admin" {
+  bucket = google_storage_bucket.terraform_state.name
+  role   = "roles/storage.admin"
+  member = "serviceAccount:${google_service_account.terraform_gcs.email}"
+}
+
+# ---------- Workload Identity Federation ----------
+
+resource "google_iam_workload_identity_pool" "github" {
+  workload_identity_pool_id = "github-actions"
+  display_name              = "GitHub Actions"
+  description               = "Identity pool for GitHub Actions OIDC"
+
+  depends_on = [google_project_service.required_apis]
+}
+
+resource "google_iam_workload_identity_pool_provider" "github" {
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github.workload_identity_pool_id
+  workload_identity_pool_provider_id = "github-oidc"
+  display_name                       = "GitHub OIDC"
+
+  attribute_mapping = {
+    "google.subject"       = "assertion.sub"
+    "attribute.actor"      = "assertion.actor"
+    "attribute.repository" = "assertion.repository"
+  }
+
+  attribute_condition = "assertion.repository == \"${var.github_repo}\""
+
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+}
+
+# ---------- WIF → Service Account Impersonation ----------
+
+resource "google_service_account_iam_member" "wif_gke" {
+  service_account_id = google_service_account.terraform_gke.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/attribute.repository/${var.github_repo}"
+}
+
+resource "google_service_account_iam_member" "wif_gcs" {
+  service_account_id = google_service_account.terraform_gcs.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/attribute.repository/${var.github_repo}"
+}

--- a/main.tf
+++ b/main.tf
@@ -8,10 +8,7 @@ terraform {
     }
   }
 
-  backend "gcs" {
-    bucket = "sandbox-juangar-terraform-state"
-    prefix = "terraform/state"
-  }
+  backend "gcs" {}
 }
 
 # Configure the Google Cloud provider to manage resources.

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,0 +1,5 @@
+# Copy this file to terraform.tfvars and fill in your values.
+# terraform.tfvars is gitignored and will not be committed.
+
+project_id = "your-gcp-project-id"
+region     = "us-central1"

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,6 @@
 variable "project_id" {
   description = "The Google Cloud project ID to deploy the resources in."
   type        = string
-  default     = "sandbox-juangar" # Replace with your actual project ID
 }
 
 variable "region" {


### PR DESCRIPTION
## Summary

- Removes all hardcoded `sandbox-juangar` references from Terraform config and GitHub Actions workflows — no more find-and-replace when switching projects
- Adds `bootstrap/wif.tf` to create the full Workload Identity Federation stack (pool, OIDC provider, service accounts, IAM bindings) via Terraform instead of manual `gcloud` commands
- Switches the bootstrap to use local state (fixes the chicken-and-egg problem where the bootstrap stored its state in the bucket it was creating)
- Adds `terraform.tfvars.example` templates so the setup steps are clear for any new project

## New setup flow for a fresh GCP project

\`\`\`bash
# 1. Authenticate locally
gcloud auth application-default login

# 2. Fill in bootstrap variables
cp bootstrap/terraform.tfvars.example bootstrap/terraform.tfvars
# edit: project_id and github_repo

# 3. Run bootstrap (creates bucket + WIF + SAs + IAM)
cd bootstrap && terraform init && terraform apply

# 4. Set GitHub secrets/variable from terraform output:
#    WIF_PROVIDER              <- terraform output wif_provider
#    WIF_SERVICE_ACCOUNT_GKE  <- terraform output service_account_gke
#    WIF_SERVICE_ACCOUNT_GCS  <- terraform output service_account_gcs
#    vars.GCP_PROJECT_ID      <- repository variable (Actions > Variables)

# 5. GitHub Actions workflows work from here on
\`\`\`

## Test plan

- [ ] Run \`terraform fmt -check -recursive\` — passes
- [ ] Run \`terraform validate\` in \`bootstrap/\` after \`terraform init\`
- [ ] Run \`terraform validate\` in root after \`terraform init -backend-config="bucket=<bucket>" -backend-config="prefix=terraform/state"\`
- [ ] Trigger bootstrap workflow (apply) on a fresh GCP project and verify outputs
- [ ] Verify \`terraform.tfvars.example\` files are tracked by git (not gitignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)