### PR TITLE
Remove WIF pool/provider from Terraform, use manually created pool

### DIFF
--- a/bootstrap/outputs.tf
+++ b/bootstrap/outputs.tf
@@ -8,11 +8,6 @@ output "state_bucket_url" {
   value       = google_storage_bucket.terraform_state.url
 }
 
-output "wif_provider" {
-  description = "WIF provider resource name — set as WIF_PROVIDER GitHub secret"
-  value       = google_iam_workload_identity_pool_provider.github.name
-}
-
 output "service_account_gke" {
   description = "GKE service account email — set as WIF_SERVICE_ACCOUNT_GKE GitHub secret"
   value       = google_service_account.terraform_gke.email

--- a/bootstrap/terraform.tfvars.example
+++ b/bootstrap/terraform.tfvars.example
@@ -1,6 +1,7 @@
 # Copy this file to terraform.tfvars and fill in your values.
 # terraform.tfvars is gitignored and will not be committed.
 
-project_id  = "your-gcp-project-id"
-region      = "us-central1"
-github_repo = "your-github-username/your-repo-name"
+project_id    = "your-gcp-project-id"
+region        = "us-central1"
+github_repo   = "your-github-username/your-repo-name"
+wif_pool_name = "projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID"

--- a/bootstrap/variables.tf
+++ b/bootstrap/variables.tf
@@ -13,3 +13,8 @@ variable "github_repo" {
   description = "The GitHub repository allowed to authenticate via WIF (owner/repo)."
   type        = string
 }
+
+variable "wif_pool_name" {
+  description = "The WIF pool resource name from the GCP console (projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID)."
+  type        = string
+}

--- a/bootstrap/wif.tf
+++ b/bootstrap/wif.tf
@@ -51,44 +51,19 @@ resource "google_storage_bucket_iam_member" "gcs_state_admin" {
   member = "serviceAccount:${google_service_account.terraform_gcs.email}"
 }
 
-# ---------- Workload Identity Federation ----------
-
-resource "google_iam_workload_identity_pool" "github" {
-  workload_identity_pool_id = "github-actions"
-  display_name              = "GitHub Actions"
-  description               = "Identity pool for GitHub Actions OIDC"
-
-  depends_on = [google_project_service.required_apis]
-}
-
-resource "google_iam_workload_identity_pool_provider" "github" {
-  workload_identity_pool_id          = google_iam_workload_identity_pool.github.workload_identity_pool_id
-  workload_identity_pool_provider_id = "github-oidc"
-  display_name                       = "GitHub OIDC"
-
-  attribute_mapping = {
-    "google.subject"       = "assertion.sub"
-    "attribute.actor"      = "assertion.actor"
-    "attribute.repository" = "assertion.repository"
-  }
-
-  attribute_condition = "assertion.repository == \"${var.github_repo}\""
-
-  oidc {
-    issuer_uri = "https://token.actions.githubusercontent.com"
-  }
-}
-
 # ---------- WIF → Service Account Impersonation ----------
+# The WIF pool and provider are managed manually in the GCP console.
+# var.wif_pool_name is the pool resource name, e.g.:
+#   projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID
 
 resource "google_service_account_iam_member" "wif_gke" {
   service_account_id = google_service_account.terraform_gke.name
   role               = "roles/iam.workloadIdentityUser"
-  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/attribute.repository/${var.github_repo}"
+  member             = "principalSet://iam.googleapis.com/${var.wif_pool_name}/attribute.repository/${var.github_repo}"
 }
 
 resource "google_service_account_iam_member" "wif_gcs" {
   service_account_id = google_service_account.terraform_gcs.name
   role               = "roles/iam.workloadIdentityUser"
-  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/attribute.repository/${var.github_repo}"
+  member             = "principalSet://iam.googleapis.com/${var.wif_pool_name}/attribute.repository/${var.github_repo}"
 }


### PR DESCRIPTION
## Summary

- Removes `google_iam_workload_identity_pool` and `google_iam_workload_identity_pool_provider` from `bootstrap/wif.tf` — WIF is created once manually in the GCP console, Terraform shouldn't manage it
- WIF → SA impersonation bindings are kept but now reference the pool via a `wif_pool_name` variable instead of a Terraform resource
- Adds `wif_pool_name` to `bootstrap/variables.tf` and `bootstrap/terraform.tfvars.example`
- Removes the `wif_provider` output from `bootstrap/outputs.tf` (no longer a Terraform resource)

## Setup flow

```bash
# 1. Authenticate locally
gcloud auth application-default login

# 2. Fill in bootstrap variables
cp bootstrap/terraform.tfvars.example bootstrap/terraform.tfvars
# set: project_id, github_repo, wif_pool_name
# wif_pool_name is shown in GCP console under
# IAM → Workload Identity Federation → your pool → copy resource name

# 3. Run bootstrap (creates state bucket + SAs + IAM bindings)
cd bootstrap && terraform init && terraform apply

# 4. Set GitHub secrets from outputs:
#    terraform output service_account_gke  → WIF_SERVICE_ACCOUNT_GKE
#    terraform output service_account_gcs  → WIF_SERVICE_ACCOUNT_GCS
#    WIF_PROVIDER = full provider resource name (from GCP console)
#    GCP_PROJECT_ID = your project ID (repo variable)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)